### PR TITLE
fix: update CI workflow to use matrix for Go versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,10 @@ on:
 jobs:
   check-application:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.23, 1.24]
+        os: [ubuntu-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -19,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.24'
+          go-version: ${{ matrix.go-version }}
 
       - name: Install dependencies
         run: go mod download


### PR DESCRIPTION
This pull request updates the CI workflow to support testing across multiple Go versions, improving compatibility and ensuring the application works with different environments.

### CI workflow improvements:
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR15-R26): Introduced a matrix strategy to test the application on Go versions 1.23 and 1.24, allowing for broader compatibility testing. Updated the `go-version` parameter to use the matrix value instead of a fixed version.