### PR TITLE
fix: update CI workflow to include additional OS support and remove d…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23, 1.24]
-        os: [ubuntu-latest]
+        # go-version: [1.23, 1.24]
+        go-version: [1.24]
+        os: [ubuntu-latest,"ubuntu-arm64-latest"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
This pull request updates the CI workflow configuration to adjust the Go version matrix and expand the operating system coverage.

### CI Workflow Updates:
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL17-R19): Removed Go 1.23 from the version matrix, keeping only Go 1.24. Added support for `ubuntu-arm64-latest` alongside `ubuntu-latest` in the operating system matrix.…eprecated Go versions