### PR TITLE
feat: update CI workflow to build and push Docker image to GitHub Con…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,11 +41,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile.prod
           platforms: linux/amd64,linux/arm64
-          push: false
-          tags: fpessoa64/ci-go:${{ matrix.go-version }}-${{ matrix.os }}
+          push: true
+          tags: |
+            ghcr.io/segment-ia/ci-go:latest
+            ghcr.io/segment-ia/ci-go:${{ github.sha }}


### PR DESCRIPTION
This pull request updates the CI workflow to enhance Docker image management by integrating GitHub Container Registry (GHCR) and modifying the build and push process.

### Updates to CI workflow:

* **GitHub Container Registry integration**:
  - Added a step to log in to the GitHub Container Registry using the `docker/login-action@v2` action. This uses the `GITHUB_TOKEN` secret for authentication. (`.github/workflows/ci.yaml`, [.github/workflows/ci.yamlR44-R60](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR44-R60))

* **Docker image build and push**:
  - Updated the `docker/build-push-action@v2` step to enable pushing Docker images and changed the tags to include `ghcr.io` references (`latest` and the current commit SHA). (`.github/workflows/ci.yaml`, [.github/workflows/ci.yamlR44-R60](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR44-R60))…tainer Registry