### PR TITLE
Feature/docker ci 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,11 @@ on:
   pull_request:
     branches:
       - develop
-   
+
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   check-application:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,11 +41,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile.prod
           platforms: linux/amd64,linux/arm64
-          push: false
-          tags: fpessoa64/ci-go:${{ matrix.go-version }}-${{ matrix.os }}
+          push: true
+          tags: |
+            ghcr.io/segment-ia/ci-go:latest
+            ghcr.io/segment-ia/ci-go:${{ github.sha }}


### PR DESCRIPTION
This pull request updates the CI workflow configuration to enhance security and enable Docker image publishing to GitHub Container Registry (GHCR). The most important changes include adding permissions for the workflow, configuring Docker login, and modifying the Docker build and push steps.

### CI Workflow Enhancements:

* **Added permissions for the workflow**: The `permissions` section was added to grant `read` access to contents and `write` access to packages, improving security by explicitly defining required permissions (`.github/workflows/ci.yaml`, [.github/workflows/ci.yamlR12-R15](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR12-R15)).

* **Configured Docker login for GHCR**: A new step was added to log in to the GitHub Container Registry using the `docker/login-action@v2`, enabling the workflow to authenticate with GHCR (`.github/workflows/ci.yaml`, [.github/workflows/ci.yamlR48-R64](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR48-R64)).

* **Modified Docker build and push steps**: The workflow now pushes Docker images to GHCR with `latest` and commit-specific tags, replacing the previous configuration that pushed images to Docker Hub (`.github/workflows/ci.yaml`, [.github/workflows/ci.yamlR48-R64](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR48-R64)).